### PR TITLE
fix(dark-mode): install @tailwindcss/typography plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	},
 	"dependencies": {
 		"@shikijs/rehype": "^3.22.0",
+		"@tailwindcss/typography": "^0.5.19",
 		"@upstash/redis": "^1.36.2",
 		"@vercel/analytics": "^1.6.1",
 		"@vercel/functions": "^3.4.2",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,142 +2,142 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <url>
   <loc>https://decrypt.im/</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/contact</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/experiments</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/8sprod</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/abprod</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/adan</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/app-ui</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/bettercmc</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/capybarapp</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/claudemeter</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/crafted</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/cryptoast</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/cryptodaily</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/cube3</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/decrypt-ui</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/defillama</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/itwink</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/logo</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/lutincognito</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/nft</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/nodeguides</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/oak</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/octopot</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/pandia</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/rufiji</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/webdesign</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/wlf</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/projects/zigdex</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/experiments/card-spotlight</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/experiments/card-tilt</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/experiments/dot-pattern</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/experiments/keyboard</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/experiments/meteor</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 <url>
   <loc>https://decrypt.im/experiments/orbit</loc>
-  <lastmod>2026-02-17T20:33:39.059Z</lastmod>
+  <lastmod>2026-02-17T20:44:00.723Z</lastmod>
 </url>
 </urlset>

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@plugin "@tailwindcss/typography";
 
 @layer base {
 	.text-edge-outline {


### PR DESCRIPTION
The prose, prose-zinc, and dark:prose-invert classes were no-ops because the typography plugin was never installed. Added the plugin and registered it in global.css so dark mode text is now properly readable on project and experiment pages.